### PR TITLE
Fix waiver file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A cookbook to run inspec scans against remote nodes and report back to Chef Automate
 
-# Usage
+## Usage
 
 Create a wrapper cookbook and add a dependency on `remote_audit` in `metadata.rb`
 
@@ -12,14 +12,14 @@ depends 'remote_audit'
 
 In the wrapper cookbook recipe, use the `remote_audit_scan` resource to run the audit and report to ChefAutomate
 
-# actions
+## actions
 
 | Action          | Description                            |
 |-----------------|----------------------------------------|
 | `:run`          | execute the remote scan                |
 | `:nothing`      | do nothing                             |
 
-# properties
+## properties
 
 | Property        | Description                                                                    | Required|
 |-----------------|--------------------------------------------------------------------------------|---------|
@@ -27,7 +27,7 @@ In the wrapper cookbook recipe, use the `remote_audit_scan` resource to run the 
 | `node_name`     | a unique name that represents the target host.                                 | Yes     |
 | `target`        | an inspec remote target string                                                 | No      |
 | `inputs`        | a hash of Inspec Inputs                                                        | No      |
-| `waiverfile`    | a waiverfile (or an array of them)                                             | No      |
+| `waiverfiles`   | an array of waiverfile filenames                                               | No      |
 | `policy_name`   | the policyname to show in Automate (default is the policyname of this node)    | No      |
 | `policy_group`  | the policygroup to show in Automate (defaults to the policygroup of this node) | No      |
 | `chef_tags`     | the tags which should be applied for this report                               | No      |
@@ -37,7 +37,7 @@ In the wrapper cookbook recipe, use the `remote_audit_scan` resource to run the 
 | `environment`   | the environment to show in Automate                                            | No      |
 | `organization`  | the organization to show in Automate (defaults to the org of this node)        | No      |
 
-# Example - A remote scan with 2 profiles
+## Example - A remote scan with 2 profiles
 
 ``` ruby
 remote_audit_scan 'ncc-1701 multiple profiles' do
@@ -50,7 +50,7 @@ remote_audit_scan 'ncc-1701 multiple profiles' do
 end
 ```
 
-# Example - A local scan with inputs
+## Example - A local scan with inputs
 
 ``` ruby
 remote_audit_scan 'a local database' do
@@ -62,5 +62,39 @@ remote_audit_scan 'a local database' do
     oracle_home: "/u01/apps/oracle",
     oracle_sid:  "database1"
   )
+end
+```
+
+## Example - A scan with waivers
+
+First off, make sure we have a waiverfile describing what we want to waive. If you alerady have a waiverfile, you can skip this step.
+
+``` ruby
+# Declare a waiver structure for the controls we want to skip
+waivers = {
+  "crew-must-be-humans" => {
+    "expiration_date" => "2085-12-25",
+    "run"             => false,
+    "justification"   => "Without Spock we're doomed"
+  }
+}
+
+# Lets put the waiverfile in Chef's cache directory
+waiver_filename = "#{Chef::Config[:file_cache_path]}/ncc1701-waivers.yml"
+
+# And write the structure to file making sure to convert to YAML
+file waiver_filename do
+  content waivers.to_yaml
+end
+```
+
+Now use the waiverfile in a scan. The scan expects an **Array** of waiverfile filenames (because we can use multiple waiverfiles)
+
+``` ruby
+remote_audit_scan 'ncc-1701' do
+  profiles [ { source: 'chef', owner: 'admin', profile: 'sample' } ]
+  node_name 'ncc-1701'
+  target 'ssh://kirk@ncc-1701'
+  waiverfiles [ waiver_filename ]
 end
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'richard.nixon@btinternet.com'
 license 'Apache-2.0'
 description 'Installs/Configures remote_audit'
 long_description 'Installs/Configures remote_audit'
-version '1.1.3'
+version '2.0.0'
 chef_version '>= 13.0'
 
 issues_url 'https://github.com/trickyearlobe/remote_audit/issues'

--- a/resources/scan.rb
+++ b/resources/scan.rb
@@ -4,7 +4,7 @@ property :profiles, Array, required: true
 property :node_name, String, required: true
 property :target, String, required: false, sensitive: true
 property :inputs, Hash, required: false, sensitive: true
-property :waiverfile, Hash, required: false, sensitive: false
+property :waiverfiles, Array, required: false, sensitive: false
 property :policy_name, String, default: node['policy_name'] || "not_set"
 property :policy_group, String, default: node['policy_group'] || "not_set"
 property :chef_tags, Array, default: ['remote_audit']
@@ -23,7 +23,7 @@ action :run do
     opts = { "report" => true }
     opts['target']  = new_resource.target if new_resource.target
     opts['inputs']  = new_resource.inputs if new_resource.inputs
-    opts['waiverfile'] = Array(new_resource.waiverfile) if new_resource.waiverfile
+    opts['waiver_file'] = new_resource.waiverfiles if new_resource.waiverfiles
 
     Chef::Log.debug "Starting scan of node #{new_resource.node_name} with guid #{guid}"
     runner = Inspec::Runner.new(opts)


### PR DESCRIPTION
* Makes `waiverfiles` an array of strings (the waiverfile paths)
* Corrects a type in passing the waiverfiles parameter to Inspec

Signed-off-by: Richard Nixon <richard.nixon@btinternet>